### PR TITLE
Add create person endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem 'jbuilder'
 gem 'active_model_serializers'
 gem 'jsonapi-serializer'
 
+# Validation
+gem 'dry-validation'
+
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,41 @@ GEM
     diff-lcs (1.6.2)
     dotenv (3.1.8)
     drb (2.2.3)
+    dry-configurable (1.3.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-core (1.1.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-inflector (1.2.0)
+    dry-initializer (3.2.0)
+    dry-logic (1.6.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-schema (1.14.1)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 1.0, >= 1.0.1)
+      dry-core (~> 1.1)
+      dry-initializer (~> 3.2)
+      dry-logic (~> 1.5)
+      dry-types (~> 1.8)
+      zeitwerk (~> 2.6)
+    dry-types (1.8.3)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
+    dry-validation (1.11.1)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      dry-initializer (~> 3.2)
+      dry-schema (~> 1.14)
+      zeitwerk (~> 2.6)
     ed25519 (1.4.0)
     erb (5.0.2)
     erubi (1.13.1)
@@ -359,6 +394,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   debug
+  dry-validation
   factory_bot_rails
   faker
   importmap-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,15 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+  protect_from_forgery with: :null_session, if: -> { request.format.json? }
+
+  private
+
+  def errors_hash(status, title, detail)
+    {
+      status:,
+      title:,
+      detail:
+    }
+  end
 end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -7,13 +7,24 @@ class PeopleController < ApplicationController
     else
       render json: {
         errors: [
-          {
-            status: '404',
-            title: 'Not Found',
-            detail: 'Person not found'
-          }
+          errors_hash(404, 'Not Found', 'Person not found')
         ]
       }, status: :not_found
+    end
+  end
+
+  def create
+    attributes = params.to_unsafe_h.dig(:data, :attributes) || {}
+    result = PeopleService.create(attributes)
+
+    if result.is_a?(Person)
+      render json: PersonSerializer.new(result).serializable_hash, status: :created
+    else
+      render json: {
+        errors: result[:errors].map do |field, messages|
+          errors_hash(400, 'Bad Request', "#{field}: #{Array(messages).join(', ')}")
+        end
+      }, status: :bad_request
     end
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -12,6 +12,7 @@ class Person < ApplicationRecord
   before_validation { self.uid = SecureRandom.uuid }
 
   VALID_RELATIONS = [ 'Friend', 'Mother', 'Father', 'Sister', 'Brother', 'Son', 'Daughter', 'Wife', 'Uncle', 'Aunt', 'Colleague', 'Other' ]
+  public_constant :VALID_RELATIONS
 
   private
 

--- a/app/services/people_service.rb
+++ b/app/services/people_service.rb
@@ -2,4 +2,14 @@ class PeopleService
   def self.find_by_uid(uid)
     Person.find_by(uid:)
   end
+
+  def self.create(params)
+    validation_result = PeopleValidator.new.call(params)
+
+    if validation_result.success?
+      Person.create!(params)
+    else
+      { errors: validation_result.errors.to_h }
+    end
+  end
 end

--- a/app/validators/people_validator.rb
+++ b/app/validators/people_validator.rb
@@ -1,0 +1,58 @@
+class PeopleValidator < Dry::Validation::Contract
+  params do
+    required(:name).filled(:string)
+    optional(:phone_number).maybe(:string)
+    optional(:email).maybe(:string)
+    optional(:date_of_birth).maybe(:date)
+    required(:relation).filled(:string)
+  end
+
+  rule(:name) do
+    if value.present? && value.length < 2
+      key.failure('must be at least 2 characters long')
+    end
+  end
+
+  rule(:phone_number) do
+    if value.present?
+      # Basic phone number validation - allows various formats
+      unless value.match?(/\A[\d\s\-\+\(\)\.]+\z/)
+        key.failure('must contain only digits, spaces, hyphens, plus signs, parentheses, and dots')
+      end
+    end
+  end
+
+  rule(:email) do
+    if value.present?
+      # More comprehensive email validation that rejects consecutive dots
+      email_regex = /\A[\w+\-]+(\.[\w+\-]+)*@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+      unless value.match?(email_regex)
+        key.failure('must be a valid email address')
+      end
+    end
+  end
+
+  rule(:date_of_birth) do
+    if value.present?
+      if value > Date.current
+        key.failure('cannot be in the future')
+      end
+
+      if value < Date.current - 100.years
+        key.failure('cannot be more than 100 years ago')
+      end
+    end
+  end
+
+  rule(:relation) do
+    unless Person::VALID_RELATIONS.include?(value)
+      key.failure("must be one of the following: #{Person::VALID_RELATIONS.join(', ')}")
+    end
+  end
+
+  rule(:phone_number, :email) do
+    if values[:phone_number].blank? && values[:email].blank?
+      key(:base).failure('at least one contact method (phone number or email) must be provided')
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   resources :people, only: [:show], param: :uid
+  resources :people, only: [:create]
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.

--- a/requests/People/create_person.bru
+++ b/requests/People/create_person.bru
@@ -1,0 +1,26 @@
+meta {
+  name: create_person
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/people
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "data": {
+      "type": "people",
+      "attributes": {
+        "name": "John Doe",
+        "phone_number": "07412345678",
+        "email": "hello@example.com",
+        "date_of_birth": "1990-01-01",
+        "relation": "Friend"
+      }
+    }
+  }
+}

--- a/spec/requests/create_people_spec.rb
+++ b/spec/requests/create_people_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe 'People', type: :request do
+  describe 'POST /people' do
+    let(:valid_attributes) do
+      {
+        name: 'John Doe',
+        phone_number: '+1-555-123-4567',
+        email: 'john@example.com',
+        date_of_birth: '1990-01-01',
+        relation: 'Friend'
+      }
+    end
+
+    let(:request_payload) do
+      {
+        data: {
+          type: 'people',
+          attributes:
+        }
+      }
+    end
+    let(:attributes) { valid_attributes }
+
+    subject(:create_person) { post '/people', params: request_payload, as: :json }
+
+    context 'with valid parameters' do
+      it 'creates a new person and returns 201 status' do
+        expect { create_person }.to change(Person, :count).by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(JSON.parse(response.body)).to eq(
+          'data' => {
+            'type' => 'people',
+            'attributes' => {
+              'name' => 'John Doe',
+              'phone_number' => '+1-555-123-4567',
+              'email' => 'john@example.com',
+              'date_of_birth' => '1990-01-01',
+              'relation' => 'Friend'
+            },
+            'id' => Person.last.uid
+          }
+        )
+      end
+    end
+
+    context 'with invalid parameters' do
+      let(:attributes) { {} }
+
+      it 'does not create a new person and returns validation errors for invalid fields' do
+        expect { create_person }.not_to change(Person, :count)
+
+        expect(response).to have_http_status(:bad_request)
+
+        expect(JSON.parse(response.body)).to eq(
+          'errors' => [
+            {
+              'detail' => 'name: is missing',
+              'status' => 400,
+              'title' => 'Bad Request'
+            },
+            {
+              'detail' => 'relation: is missing',
+              'status' => 400,
+              'title' => 'Bad Request'
+            },
+            {
+              'detail' => 'base: at least one contact method (phone number or email) must be provided',
+              'status' => 400,
+              'title' => 'Bad Request'
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/requests/get_people_spec.rb
+++ b/spec/requests/get_people_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'People', type: :request do
         expect(JSON.parse(response.body)).to eq({
           'errors' => [
             {
-              'status' => '404',
+              'status' => 404,
               'title' => 'Not Found',
               'detail' => 'Person not found'
             }

--- a/spec/services/people_service_spec.rb
+++ b/spec/services/people_service_spec.rb
@@ -23,4 +23,55 @@ RSpec.describe PeopleService do
       end
     end
   end
+
+  describe '.create' do
+    let(:valid_params) do
+      {
+        name: 'John Doe',
+        phone_number: '1234567890',
+        email: 'john.doe@example.com',
+        date_of_birth: '1990-01-01',
+        relation: 'Friend'
+      }
+    end
+
+    it 'creates a new person' do
+      result = described_class.create(valid_params)
+      expect(result).to be_a(Person)
+    end
+
+    context 'when the params are invalid' do
+      context 'when the params are missing a required field' do
+        let(:invalid_params) { valid_params.except(:name) }
+
+        it 'returns an error hash with the invalid field' do
+          result = described_class.create(invalid_params)
+          expect(result).to eq(
+            {
+              errors: {
+                name: [ "is missing" ]
+              }
+            }
+          )
+        end
+      end
+
+      context 'when the params are empty' do
+        let(:invalid_params) { {} }
+
+        it 'returns an error hash with each field that is invalid' do
+          result = described_class.create(invalid_params)
+          expect(result).to eq(
+            {
+              errors: {
+                base: [ "at least one contact method (phone number or email) must be provided" ],
+                name: [ "is missing" ],
+                relation: [ "is missing" ]
+              }
+            }
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/validators/people_validator_spec.rb
+++ b/spec/validators/people_validator_spec.rb
@@ -1,0 +1,185 @@
+require 'rails_helper'
+
+RSpec.describe PeopleValidator do
+  let(:valid_params) do
+    {
+      name: 'John Doe',
+      phone_number: '+1-555-123-4567',
+      email: 'john@example.com',
+      date_of_birth: '1990-01-01',
+      relation: 'Friend'
+    }
+  end
+  let(:params) { valid_params }
+
+  subject { described_class.new.call(params) }
+
+  RSpec.shared_examples 'a successful validation' do
+    it 'is successful' do
+      expect(subject).to be_success
+    end
+  end
+
+  RSpec.shared_examples 'a failed validation' do |field, error_message|
+    it 'is not successful' do
+      expect(subject).to be_failure
+      expect(subject.errors[field]).to include(error_message)
+    end
+  end
+
+  context 'with valid parameters' do
+    it_behaves_like 'a successful validation'
+  end
+
+  context 'name validation' do
+    let(:params) { valid_params.except(:name) }
+
+    it_behaves_like 'a failed validation', :name, 'is missing'
+
+    context 'when name is too short' do
+      let(:params) { valid_params.merge(name: 'A') }
+
+      it_behaves_like 'a failed validation', :name, 'must be at least 2 characters long'
+    end
+  end
+
+  context 'phone number validation' do
+    context 'when phone number is valid' do
+      valid_phones = [
+        '+1-555-123-4567',
+        '(555) 123-4567',
+        '555.123.4567',
+        '555 123 4567',
+        '+44 20 7946 0958'
+      ]
+
+      valid_phones.each do |phone|
+        let(:params) { valid_params.merge(phone_number: phone) }
+
+        it_behaves_like 'a successful validation'
+      end
+    end
+
+    context 'when phone number is invalid' do
+      invalid_phones = [
+        'abc123',
+        '555-123-4567!',
+        '555@123#4567'
+      ]
+      invalid_phones.each do |phone|
+        let(:params) { valid_params.merge(phone_number: phone) }
+
+        it_behaves_like 'a failed validation', :phone_number, 'must contain only digits, spaces, hyphens, plus signs, parentheses, and dots'
+      end
+    end
+
+    context 'when phone number is not present' do
+      let(:params) { valid_params.except(:phone_number) }
+
+      it_behaves_like 'a successful validation'
+    end
+  end
+
+  context 'email validation' do
+    context 'when email is valid' do
+      valid_emails = [
+        'user@example.com',
+        'user.name@example.co.uk',
+        'user+tag@example.org'
+      ]
+      valid_emails.each do |email|
+        let(:params) { valid_params.merge(email: email) }
+
+        it_behaves_like 'a successful validation'
+      end
+    end
+
+    context 'when email is invalid' do
+      invalid_emails = [
+        'invalid-email',
+        '@example.com',
+        'user@',
+        'user..name@example.com'
+      ]
+      invalid_emails.each do |email|
+        let(:params) { valid_params.merge(email: email) }
+
+        it_behaves_like 'a failed validation', :email, 'must be a valid email address'
+      end
+    end
+
+    context 'when email is not present' do
+      let(:params) { valid_params.except(:email) }
+
+      it_behaves_like 'a successful validation'
+    end
+  end
+
+  context 'date of birth validation' do
+    context 'when date of birth is valid' do
+      let(:params) { valid_params.merge(date_of_birth: '1990-01-01') }
+
+      it_behaves_like 'a successful validation'
+    end
+
+    context 'when date of birth is in the future' do
+      let(:params) { valid_params.merge(date_of_birth: (Date.current + 1.day).to_s) }
+
+      it_behaves_like 'a failed validation', :date_of_birth, 'cannot be in the future'
+    end
+
+    context 'when date of birth is too far in the past' do
+      let(:params) { valid_params.merge(date_of_birth: (Date.current - 101.years).to_s) }
+
+      it_behaves_like 'a failed validation', :date_of_birth, 'cannot be more than 100 years ago'
+    end
+
+    context 'when date of birth is not present' do
+      let(:params) { valid_params.except(:date_of_birth) }
+
+      it_behaves_like 'a successful validation'
+    end
+  end
+
+  context 'relation validation' do
+    context 'when relation is present' do
+      let(:params) { valid_params.merge(relation: 'Friend') }
+
+      it_behaves_like 'a successful validation'
+    end
+
+    context 'when relation is valid' do
+      Person::VALID_RELATIONS.each do |relation|
+        let(:params) { valid_params.merge(relation: relation) }
+
+        it_behaves_like 'a successful validation'
+      end
+    end
+
+    context 'when relation is invalid' do
+      let(:params) { valid_params.merge(relation: 'InvalidRelation') }
+
+      it_behaves_like 'a failed validation', :relation, "must be one of the following: #{Person::VALID_RELATIONS.join(', ')}"
+    end
+  end
+
+  context 'contact method validation' do
+    context 'when at least one contact method is present' do
+      let(:params) { valid_params.except(:phone_number, :email) }
+
+      it_behaves_like 'a failed validation', :base, 'at least one contact method (phone number or email) must be provided'
+    end
+
+    context 'when only phone number is provided' do
+      let(:params) { valid_params.except(:email) }
+
+      it_behaves_like 'a successful validation'
+    end
+
+    context 'when only email is provided' do
+      let(:params) { valid_params.except(:phone_number) }
+
+      it_behaves_like 'a successful validation'
+    end
+  end
+end

--- a/spec/validators/people_validator_spec.rb
+++ b/spec/validators/people_validator_spec.rb
@@ -45,29 +45,34 @@ RSpec.describe PeopleValidator do
 
   context 'phone number validation' do
     context 'when phone number is valid' do
-      valid_phones = [
-        '+1-555-123-4567',
-        '(555) 123-4567',
-        '555.123.4567',
-        '555 123 4567',
-        '+44 20 7946 0958'
-      ]
+      context 'when phone number is a valid UK number' do
+        let(:params) { valid_params.merge(phone_number: '+442079460958') }
 
-      valid_phones.each do |phone|
-        let(:params) { valid_params.merge(phone_number: phone) }
+        it_behaves_like 'a successful validation'
+      end
+
+      context 'when phone number is a valid UK number with spaces' do
+        let(:params) { valid_params.merge(phone_number: '+44 20 7946 0958') }
+
+        it_behaves_like 'a successful validation'
+      end
+
+      context 'when phone number is a valid India number' do
+        let(:params) { valid_params.merge(phone_number: '+919876543210') }
 
         it_behaves_like 'a successful validation'
       end
     end
 
     context 'when phone number is invalid' do
-      invalid_phones = [
-        'abc123',
-        '555-123-4567!',
-        '555@123#4567'
-      ]
-      invalid_phones.each do |phone|
-        let(:params) { valid_params.merge(phone_number: phone) }
+      context 'when phone number contains letters' do
+        let(:params) { valid_params.merge(phone_number: 'abc123') }
+
+        it_behaves_like 'a failed validation', :phone_number, 'must contain only digits, spaces, hyphens, plus signs, parentheses, and dots'
+      end
+
+      context 'when phone number contains special characters' do
+        let(:params) { valid_params.merge(phone_number: '555-123-4567!') }
 
         it_behaves_like 'a failed validation', :phone_number, 'must contain only digits, spaces, hyphens, plus signs, parentheses, and dots'
       end


### PR DESCRIPTION
Add an endpoint to create a person. This endpoint has validations on the request body (which must be json api compliant), plus nicer error handling thanks to the dry-validation gem. Also add an example bruno request